### PR TITLE
Add option to force Arabic language regardless of system locale

### DIFF
--- a/schemas/org.gnome.shell.extensions.athan.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.athan.gschema.xml
@@ -38,6 +38,12 @@
         <description>Set time format to AM/PM hours</description>
     </key>
 
+    <key type="b" name="use-arabic">
+        <default>false</default>
+        <summary>Use Arabic language</summary>
+        <description>Force extension to use Arabic language regardless of system locale</description>
+    </key>
+
     <key type="i" name="timezone">
         <default>0</default>
         <summary>Timezone</summary>

--- a/src/extension.js
+++ b/src/extension.js
@@ -304,6 +304,12 @@ const Azan = GObject.registerClass(
                     this._panelPositionArr[this._opt_panel_position];
                 this._updatePanelPosition();
             });
+
+            connectSetting('use-arabic', 'boolean', () => {
+                // Language change requires extension reload
+                // This handler is mainly for notification purposes
+                this._updateLabel();
+            });
         }
 
         _loadSettings() {
@@ -728,8 +734,32 @@ export default class AzanExtension extends Extension {
     enable() {
         this._settings = this.getSettings('org.gnome.shell.extensions.athan');
         this._settingsChangedIds = [];
+        
+        // Check use-arabic setting and set LANGUAGE environment variable
+        const useArabic = this._settings.get_boolean('use-arabic');
+        if (useArabic) {
+            GLib.setenv('LANGUAGE', 'ar', true);
+        }
+        
         this._settingsChangedIds.push(
             this._settings.connect('changed::panel-position', () => {
+                this._updateAzan();
+            })
+        );
+        this._settingsChangedIds.push(
+            this._settings.connect('changed::use-arabic', () => {
+                const useArabic = this._settings.get_boolean('use-arabic');
+                if (useArabic) {
+                    GLib.setenv('LANGUAGE', 'ar', true);
+                } else {
+                    GLib.unsetenv('LANGUAGE');
+                }
+                // Show notification that extension needs reload
+                Main.notify(
+                    _('Extension needs reload'),
+                    _('Please disable and re-enable the extension to apply language changes.')
+                );
+                // Attempt to reload the extension
                 this._updateAzan();
             })
         );

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -38,6 +38,10 @@ class Settings {
         this.field_time_format_12_toggle = new Adw.SwitchRow({
             title: _('AM/PM time format'),
         });
+        this.field_use_arabic_toggle = new Adw.SwitchRow({
+            title: _('Force Arabic'),
+            subtitle: _('Restart extension to apply.'),
+        });
         this.field_azan_notification_toggle = new Adw.SwitchRow({
             title: _("Notify me when it's athan time"),
         });
@@ -107,6 +111,7 @@ class Settings {
         this.displayGroup = new Adw.PreferencesGroup({ title: _('Display') });
         this.displayGroup.add(this.field_panel_position);
         this.displayGroup.add(this.field_time_format_12_toggle);
+        this.displayGroup.add(this.field_use_arabic_toggle);
         this.displayGroup.add(this.field_which_times_mode);
 
         this.notificationsGroup = new Adw.PreferencesGroup({
@@ -132,6 +137,12 @@ class Settings {
         this.schema.bind(
             'time-format-12',
             this.field_time_format_12_toggle,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.schema.bind(
+            'use-arabic',
+            this.field_use_arabic_toggle,
             'active',
             Gio.SettingsBindFlags.DEFAULT
         );


### PR DESCRIPTION
This PR adds a new preference option that allows users to force the extension to use Arabic language regardless of their system locale.

## Changes
- Added `use-arabic` schema key to enable/disable Arabic language forcing
- Added "Force Arabic" toggle in the preferences UI (Display section)
- Set LANGUAGE environment variable when Arabic mode is enabled
- Added notification to user when extension reload is needed for language changes

## Benefits
- Users can now use Arabic interface even if their system is set to a different language
- Provides more flexibility for users who want Arabic language but don't want to change their system-wide locale

## Testing
- Toggle can be enabled/disabled in preferences
- Extension respects the setting and sets LANGUAGE environment variable accordingly
- User is notified when extension reload is needed

Please let me know if any adjustments are needed. Thank you!