### PR TITLE
Add Indonesian Ulema Council (MUI) calculation method

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -152,6 +152,10 @@ msgstr "الهيئة المصرية العامة للمساحة، مصر"
 msgid "University of Islamic Sciences, Karachi"
 msgstr "معهد العالمية للدراسات الإسلامية، كاراتشي"
 
+#: src/extension.js:117 src/PrayTimes.js:26
+msgid "Indonesian Ulema Council"
+msgstr "مجلس العلماء الإندونيسي"
+
 #: src/extension.js:612
 #, javascript-format
 msgid "One minute remaining until %s prayer."

--- a/po/athan@goodm4ven.pot
+++ b/po/athan@goodm4ven.pot
@@ -152,6 +152,10 @@ msgstr ""
 msgid "University of Islamic Sciences, Karachi"
 msgstr ""
 
+#: src/extension.js:117 src/PrayTimes.js:26
+msgid "Indonesian Ulema Council"
+msgstr ""
+
 #: src/extension.js:612
 #, javascript-format
 msgid "One minute remaining until %s prayer."

--- a/po/en.po
+++ b/po/en.po
@@ -151,6 +151,10 @@ msgstr "Egyptian General Authority of Survey, Egypt"
 msgid "University of Islamic Sciences, Karachi"
 msgstr "University of Islamic Sciences, Karachi"
 
+#: src/extension.js:117 src/PrayTimes.js:26
+msgid "Indonesian Ulema Council"
+msgstr "Indonesian Ulema Council"
+
 #: src/extension.js:612
 #, javascript-format
 msgid "One minute remaining until %s prayer."

--- a/po/fa.po
+++ b/po/fa.po
@@ -152,6 +152,10 @@ msgstr "سازمان کل نقشه‌برداری مصر"
 msgid "University of Islamic Sciences, Karachi"
 msgstr "دانشگاه علوم اسلامی، کراچی"
 
+#: src/extension.js:117 src/PrayTimes.js:26
+msgid "Indonesian Ulema Council"
+msgstr "شورای علمای اندونزی"
+
 #: src/extension.js:612
 #, javascript-format
 msgid "One minute remaining until %s prayer."

--- a/src/PrayTimes.js
+++ b/src/PrayTimes.js
@@ -22,6 +22,10 @@ export function getMethods() {
             name: _('University of Islamic Sciences, Karachi'),
             params: { fajr: 18, isha: 18 },
         },
+        MUI : {
+            name: _('Indonesian Ulema Council'),
+            params: { fajr: 20, isha: 18 },
+        },
     };
 }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -108,12 +108,13 @@ const Azan = GObject.registerClass(
                 midnight: 1,
             };
 
-            this._calcMethodsArr = ['MWL', 'Makkah', 'Egypt', 'Karachi'];
+            this._calcMethodsArr = ['MWL', 'Makkah', 'Egypt', 'Karachi', 'MUI'];
             this._calcMethodNames = [
                 _('Muslim World League'),
                 _('Umm Al-Qura University, Makkah'),
                 _('Egyptian General Authority of Survey, Egypt'),
                 _('University of Islamic Sciences, Karachi'),
+                _('Indonesian Ulema Council'),
             ];
             this._timezoneArr = Array.from({ length: 27 }, (_, index) =>
                 (index - 12).toString()


### PR DESCRIPTION
## Summary
This PR adds support for the Indonesian Ulema Council (Majelis Ulama Indonesia / MUI) prayer time calculation method to the Gnome v49 extension.

## Changes
- Added `MUI` method to `src/PrayTimes.js` with parameters:
  - Fajr: -20° (Sun below eastern horizon)
  - Isha: -18° (Sun below western horizon)
- Updated `src/extension.js` to include MUI in calculation methods dropdown
- Added translations for "Indonesian Ulema Council" in:
  - English (`po/en.po`)
  - Arabic (`po/ar.po`)
  - Persian (`po/fa.po`)

## Calculation Criteria
Based on official standards from **Kementerian Agama Republik Indonesia** (Ministry of Religious Affairs):

| Prayer | Criteria |
|--------|----------|
| Imsak | 10 minutes before Fajr |
| **Fajr/Subuh** | Sun at **-20°** below eastern horizon (+2 min ihtiyat) |
| Terbit/Sunrise | Sun at horizon (-2 min ihtiyat) |
| Zuhur/Dhuhr | Sun crossing meridian (+2 min ihtiyat) |
| Ashar/Asr | Shadow length = object + zawal shadow (+2 min ihtiyat) |
| Maghrib | Sun at horizon (+2 min ihtiyat) |
| **Isha** | Sun at **-18°** below western horizon (+2 min ihtiyat) |

**Note**: The ±2 minute *ihtiyat* (precautionary adjustments) should be applied using the extension's time adjustment feature (if available) or can be added as a future enhancement.

## Reference
- **Official Criteria**: https://rukyatulhilal.org/jadwalshalat/kriteria.html
- **Published by**: LP2IF Rukyatul Hilal Indonesia (RHI)
- **Authority**: Kementerian Agama Republik Indonesia

## Testing
Tested on:
- **GNOME Shell**: 46+
- **Location**: Jakarta, Indonesia (-6.2088, 106.8456)
- **Branch**: `Gnome-v49`
- **Result**: Calculation base matches Kemenag criteria (angles: -20°/-18°)

---
@GoodM4ven  - This adds official Indonesian Ministry of Religious Affairs calculation method. Let me know if any adjustments needed!