### PR TITLE
Add configurable higher-latitudes method for Fajr and Isha

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -436,3 +436,23 @@ msgstr "10 دقائق"
 #: src/prefs.js:261
 msgid "15 min"
 msgstr "15 دقيقة"
+
+#: src/prefs.js:77
+msgid "Higher latitudes method"
+msgstr "طريقة خطوط العرض العليا"
+
+#: src/prefs.js:217
+msgid "Middle of the Night"
+msgstr "منتصف الليل"
+
+#: src/prefs.js:218
+msgid "Angle-Based"
+msgstr "حسب الزاوية"
+
+#: src/prefs.js:219
+msgid "One-Seventh of the Night"
+msgstr "سُبع الليل"
+
+#: src/prefs.js:220
+msgid "None"
+msgstr "بدون"

--- a/po/athan@goodm4ven.pot
+++ b/po/athan@goodm4ven.pot
@@ -432,3 +432,23 @@ msgstr ""
 #: src/prefs.js:261
 msgid "15 min"
 msgstr ""
+
+#: src/prefs.js:77
+msgid "Higher latitudes method"
+msgstr ""
+
+#: src/prefs.js:217
+msgid "Middle of the Night"
+msgstr ""
+
+#: src/prefs.js:218
+msgid "Angle-Based"
+msgstr ""
+
+#: src/prefs.js:219
+msgid "One-Seventh of the Night"
+msgstr ""
+
+#: src/prefs.js:220
+msgid "None"
+msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -431,3 +431,23 @@ msgstr "10 min"
 #: src/prefs.js:261
 msgid "15 min"
 msgstr "15 min"
+
+#: src/prefs.js:77
+msgid "Higher latitudes method"
+msgstr "Higher latitudes method"
+
+#: src/prefs.js:217
+msgid "Middle of the Night"
+msgstr "Middle of the Night"
+
+#: src/prefs.js:218
+msgid "Angle-Based"
+msgstr "Angle-Based"
+
+#: src/prefs.js:219
+msgid "One-Seventh of the Night"
+msgstr "One-Seventh of the Night"
+
+#: src/prefs.js:220
+msgid "None"
+msgstr "None"

--- a/po/fa.po
+++ b/po/fa.po
@@ -432,3 +432,23 @@ msgstr "۱۰ دقیقه"
 #: src/prefs.js:261
 msgid "15 min"
 msgstr "۱۵ دقیقه"
+
+#: src/prefs.js:77
+msgid "Higher latitudes method"
+msgstr ""
+
+#: src/prefs.js:217
+msgid "Middle of the Night"
+msgstr ""
+
+#: src/prefs.js:218
+msgid "Angle-Based"
+msgstr ""
+
+#: src/prefs.js:219
+msgid "One-Seventh of the Night"
+msgstr ""
+
+#: src/prefs.js:220
+msgid "None"
+msgstr ""

--- a/schemas/org.gnome.shell.extensions.athan.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.athan.gschema.xml
@@ -8,6 +8,12 @@
         <description>Calculation method</description>
     </key>
 
+    <key type="i" name="higher-latitudes-method">
+        <default>0</default>
+        <summary>Higher latitudes method</summary>
+        <description>Adjustment method for Fajr and Isha at higher latitudes, where the sun may not reach the required twilight angle</description>
+    </key>
+
     <key type="b" name="auto-location">
         <default>true</default>
         <summary>Automatic location</summary>

--- a/src/extension.js
+++ b/src/extension.js
@@ -118,6 +118,12 @@ const Azan = GObject.registerClass(
                 _('University of Islamic Sciences, Karachi'),
                 _('Indonesian Ulema Council'),
             ];
+            this._higherLatitudesArr = [
+                'NightMiddle',
+                'AngleBased',
+                'OneSeventh',
+                'None',
+            ]; // ? Mapping to PrayTimes highLats setting
             this._timezoneArr = Array.from({ length: 27 }, (_, index) =>
                 (index - 12).toString()
             );
@@ -265,6 +271,12 @@ const Azan = GObject.registerClass(
                 this._updateLabel.bind(this)
             );
 
+            connectSetting(
+                'higher-latitudes-method',
+                'int',
+                this._updateLabel.bind(this)
+            );
+
             connectSetting('latitude', 'double', this._updateLabel.bind(this));
 
             connectSetting('longitude', 'double', this._updateLabel.bind(this));
@@ -313,6 +325,7 @@ const Azan = GObject.registerClass(
             const settingsKeys = [
                 { key: 'auto-location', type: 'boolean' },
                 { key: 'calculation-method', type: 'int' },
+                { key: 'higher-latitudes-method', type: 'int' },
                 { key: 'latitude', type: 'double' },
                 { key: 'longitude', type: 'double' },
                 { key: 'time-format-12', type: 'boolean' },
@@ -513,7 +526,11 @@ const Azan = GObject.registerClass(
             this._prayTimes.setMethod(
                 this._calcMethodsArr[this._opt_calculation_method]
             );
-            this._prayTimes.adjust({ asr: 'Standard' });
+            this._prayTimes.adjust({
+                asr: 'Standard',
+                highLats:
+                    this._higherLatitudesArr[this._opt_higher_latitudes_method],
+            });
 
             return this._opt_time_format_12
                 ? this._prayTimes.getTimes(

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -73,6 +73,10 @@ class Settings {
             title: _('Calculation method'),
             model: this.#calcMethodOptions(),
         });
+        this.field_higher_latitudes_mode = new Adw.ComboRow({
+            title: _('Higher latitudes method'),
+            model: this.#higherLatitudesOptions(),
+        });
         this.field_timezone_mode = new Adw.ComboRow({
             title: _('Timezone'),
             model: this.#timezoneOptions(),
@@ -97,6 +101,7 @@ class Settings {
         });
         this.calculationGroup.add(this.field_hijri_date_adjustment);
         this.calculationGroup.add(this.field_calc_method_mode);
+        this.calculationGroup.add(this.field_higher_latitudes_mode);
         this.calculationGroup.add(this.field_timezone_mode);
 
         this.locationGroup = new Adw.PreferencesGroup({ title: _('Location') });
@@ -166,6 +171,12 @@ class Settings {
             Gio.SettingsBindFlags.DEFAULT
         );
         this.schema.bind(
+            'higher-latitudes-method',
+            this.field_higher_latitudes_mode,
+            'selected',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.schema.bind(
             'timezone',
             this.field_timezone_mode,
             'selected',
@@ -197,6 +208,20 @@ class Settings {
             // ? them with a dummy '_' function to be detected by xgettext
             // ? text extractor tool. 
             list.append(_(value.name));
+        }
+        return list;
+    }
+
+    #higherLatitudesOptions() {
+        let options = [
+            _('Middle of the Night'),
+            _('Angle-Based'),
+            _('One-Seventh of the Night'),
+            _('None'),
+        ];
+        let list = new Gtk.StringList();
+        for (let option of options) {
+            list.append(option);
         }
         return list;
     }


### PR DESCRIPTION
## Problem

At higher latitudes the sun may never reach the Fajr/Isha twilight angle, so PrayTimes applies a "higher latitudes" adjustment to keep those times sane. The extension hard-codes this rule to **Middle of the Night** (`highLats: 'NightMiddle'` in `PrayTimes.js`) and never exposes it, so Fajr/Isha can't be corrected for users above ~48° latitude.

In practice this clamps the summer Fajr/Isha towards solar midnight. For example, at **49°N on the summer solstice** with an 18°+ Fajr angle (e.g. Umm al-Qura, the default method), Fajr is reported at **01:52**, while the Angle-Based / One-Seventh rules — and local mosques — put it around **03:22–04:40**.

## Change

Expose the high-latitude rule as a setting, mapped to PrayTimes' existing `highLats` options:

| Setting | `highLats` |
|---|---|
| Middle of the Night *(default)* | `NightMiddle` |
| Angle-Based | `AngleBased` |
| One-Seventh of the Night | `OneSeventh` |
| None | `None` |

- New `higher-latitudes-method` schema key, **default `0` = Middle of the Night**, so existing setups are unchanged.
- Wired through `extension.js` (bind/load + `adjust({ highLats })`).
- New "Higher latitudes method" combo row in preferences, next to the calculation method.
- English and Arabic translations added; Persian left untranslated for a native review.

## Backward compatibility

The default preserves the previous behavior exactly. I verified the new default path produces identical times to the old hard-coded path for all five calculation methods across every day of the year (1680 method-days, 0 differences).

## Testing

- `eslint src/**/*.js` — clean.
- `node --check` on the modified files — OK.
- Schema XML validated; `msgfmt` builds all `.po` files.
- Functional check with `PrayTimes.js` at 49°N: summer Fajr moves from `01:52` (Middle of the Night) to `03:22` (Angle-Based) / `04:40` (One-Seventh); winter is unaffected (the sun reaches the angle, so no adjustment applies).

## Note (pre-existing, not part of this PR)

`xgettext` / `msgfmt --check` already fail on the existing `ngettext` string in `extension.js` ("One minute remaining…" / "%d minutes remaining…"): the singular uses `%s` and the plural uses `%d` for argument 1. It doesn't affect the normal build (`msgfmt` without `--check`), but it blocks a clean `.pot` regeneration — which is why the new strings here were added to the `.pot`/`.po` files by hand. Happy to fix that separately if useful.
